### PR TITLE
refactor(config): use header align instead of spacer

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -82,18 +82,17 @@ All navigation is in `navigation.routes`. Each route key is the URL path; the va
 
 ### navigation.header
 
-Links in the top bar. Use `type: "spacer"` to push items before it left and after it right.
+Links in the top bar. Use `align` to place each item: `"start"` (beside the logo), `"center"`, or `"end"`. Omit it and the item sits at the start.
 
 ```json
 "header": [
-  { "type": "link", "title": "Home", "to": "/" },
-  { "type": "spacer" },
-  { "type": "link", "title": "Log in", "to": "https://dashboard.example.com/login", "newTab": true },
-  { "type": "link", "title": "Register", "style": "button", "icon": "phosphor/regular/user-plus", "to": "https://...", "newTab": true }
+  { "type": "link", "title": "Home", "align": "start", "to": "/" },
+  { "type": "link", "title": "Log in", "align": "end", "to": "https://dashboard.example.com/login", "newTab": true },
+  { "type": "link", "title": "Register", "style": "button", "align": "end", "icon": "phosphor/regular/user-plus", "to": "https://...", "newTab": true }
 ]
 ```
 
-Properties: `title`, `type` (`"link"` | `"spacer"`), `to`, `style` (`"button"` | `"link"`), `icon`, `newTab`
+Properties: `title`, `type` (`"link"`), `to`, `align` (`"start"` | `"center"` | `"end"`), `style` (`"button"` | `"link"`), `icon`, `newTab`
 
 ### navigation.sidebar
 

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -13,9 +13,8 @@
   },
   "navigation": {
     "header": [
-      { "type": "spacer" },
-      { "type": "link", "title": "Log in", "to": "https://dashboard.scalar.com/login" },
-      { "type": "link", "title": "Register", "style": "button", "to": "https://dashboard.scalar.com/register" }
+      { "type": "link", "title": "Log in", "align": "end", "to": "https://dashboard.scalar.com/login" },
+      { "type": "link", "title": "Register", "style": "button", "align": "end", "to": "https://dashboard.scalar.com/register" }
     ],
     "routes": {
       "/": {


### PR DESCRIPTION
The header `spacer` is on its way out in favour of `align: start | center | end`. The starter is what new users copy, so it shouldn't be teaching the old API.

* `align: "end"` on both header links, spacer dropped
* Updates the `scalar-docs` skill's header section to match

Needs https://github.com/scalar/scalar-org/pull/5976 deployed first — until that renderer ships `align` is ignored and both links fall to the left of the header instead of the right