### PR TITLE
docs(skill): update legacy navigation fields

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -100,7 +100,7 @@ Links at the bottom of the sidebar:
 
 ```json
 "sidebar": [
-  { "title": "Log in", "url": "https://...", "style": "button", "newTab": true }
+  { "title": "Log in", "to": "https://...", "newTab": true }
 ]
 ```
 
@@ -110,7 +110,7 @@ Tabs for quick access to sections:
 
 ```json
 "tabs": [
-  { "title": "API", "path": "/api", "icon": "phosphor/regular/plug" }
+  { "title": "API", "to": "/api", "icon": "phosphor/regular/plug" }
 ]
 ```
 
@@ -282,8 +282,7 @@ For `scripts` and `styles`: path relative to config root. For `links` (favicon):
 
 ```json
 "footer": {
-  "filepath": "docs/footer.html",
-  "belowSidebar": true
+  "filepath": "docs/footer.html"
 }
 ```
 


### PR DESCRIPTION
The agent skill still teaches navigation fields that no longer exist, so it generates stale configs — the published schema is about to be republished from the current `scalarConfigSchema`.

* `sidebar[].url` → `to`, and dropped `style` (dead on sidebar items)
* `tabs[].path` → `to`
* Removed `siteConfig.footer.belowSidebar`

Left the header link example alone, header links legitimately keep `style` alongside `to`. `scalar.config.json` already validates clean so nothing changed there.

future thing: `tabs[]` also gained `type: "group"` + `children` + `newTab`, still undocumented in the skill